### PR TITLE
Provider endpoint is chosen based on environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,28 +21,35 @@ Or install it yourself as:
     $ gem install omniauth-census
 
 ## Usage
+
 #### Step 1: Register your Application
-Sign in to Census at [https://turing-census.herokuapp.com](https://turing-census.herokuapp.com).  
-Visit [Your Census Applications](https://turing-census.herokuapp.com/oauth/applications) and register your app.
-* Provide an application name
-* Provide an application redirect uri (e.g. http://your-app.com/auth/census/callback)
-* Optionally, provide a scope (note this feature is still in development)
-* Add the `CENSUS_ID`, `CENSUS_SECRET` you receive to your application's environment variables. For security, please ensure that these variables are not uploaded to GitHub or any other publicly available resource. If you need assistance with keeping these secret, consider using the [Figaro](https://github.com/laserlemon/figaro) gem. _(Figaro pronunciation: /fi.ɡa.ʁɔ/)_
+
+*   Sign in to Census at [https://turing-census.herokuapp.com](https://turing-census.herokuapp.com).  
+*   Visit [Your Census Applications](https://turing-census.herokuapp.com/oauth/applications) and register your app.
+*   Provide an application name
+*   Provide an application redirect uri (e.g. https://your-app.com/auth/census/callback)
+*   Note the values for "Application Id" and "Secret". These are your "production" values.
+*   Follow the steps above, but at <https://census-app-staging.herokuapp.com>. You will get a different set of "Application Id" and "Secret". These are your "development" values.
+
 
 #### Step 2: Configure OmniAuth
-Create the following file:
-`touch config/initializers/omniauth.rb`
 
-Add the following configuration to the above file:
-```ruby
-# config/initializers/omniauth.rb
+*   Add the `CENSUS_ID`, `CENSUS_SECRET` you receive to your application's environment variables. Use the "production" values if `RACK_ENV` is set to `production`. Use the "development" values for all other environments.
+    *   For security, please ensure that these variables are not uploaded to GitHub or any other publicly available resource. If you need assistance with keeping these secret, consider using the [Figaro](https://github.com/laserlemon/figaro) gem. _(Figaro pronunciation: /fi.ɡa.ʁɔ/)_
 
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :census, "CENSUS_ID", "CENSUS_SECRET", {
-    :name => "census"
-  }
-end
-```
+*   Create the following file:
+    `touch config/initializers/omniauth.rb`
+
+*   Add the following configuration to the above file:
+    ```ruby
+    # config/initializers/omniauth.rb
+
+    Rails.application.config.middleware.use OmniAuth::Builder do
+      provider :census, "CENSUS_ID", "CENSUS_SECRET", {
+        :name => "census"
+      }
+    end
+    ```
 
 #### Step 3: Setup Route
 In your Rails application create the following routes:
@@ -76,6 +83,14 @@ Add the following code to your desired view in order to create a Census Login Li
 
 ## Important note
 Please note that in order to use the Census OmniAuth strategy, your application must be configured to handle secured HTTPS requests. This is not the default setting on typical Rails applications run locally. For instructions on configuring SSL on a development version of your application, please consult [this guide](http://blog.napcs.com/2013/07/21/rails_ssl_simple_wa/).
+
+## Note about environments
+
+Since you can perform destructive actions on Census with your application keys, we host a "staging" and a "production" version of the Census app. That way, if you have a bug in your code, you'll only screw up the "staging" app.
+
+This gem is set to use the "production" host of Census if your application's `RACK_ENV` variable is set to `production`, and staging for all other values of `RACK_ENV` (including if it is unset).
+
+Additionally, you can force use of the production server by setting an environment variable `CENSUS_ENV=production`
 
 ## Contributing
 

--- a/lib/omniauth/strategies/census.rb
+++ b/lib/omniauth/strategies/census.rb
@@ -4,11 +4,22 @@ module OmniAuth
   module Strategies
     class Census < OmniAuth::Strategies::OAuth2
       include OmniAuth::Strategy
+
+      def self.provider_endpoint
+        
+        if ENV['CENSUS_ENV'] == 'production' || ENV['RACK_ENV'] == 'production'
+          return "https://turing-census.herokuapp.com"
+        else
+          return "https://census-app-staging.herokuapp.com"
+        end
+        
+      end
+
       option :client_options, {
-               site: "https://turing-census.herokuapp.com",
-               authorize_url: "/oauth/authorize",
-               token_url: "/oauth/token"
-             }
+         site: provider_endpoint,
+         authorize_url: "/oauth/authorize",
+         token_url: "/oauth/token"
+       }
 
       def request_phase
         super

--- a/omniauth-census.gemspec
+++ b/omniauth-census.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry", "~> 0.10.4"
   spec.add_runtime_dependency "omniauth-oauth2"
 end

--- a/spec/omniauth/census_spec.rb
+++ b/spec/omniauth/census_spec.rb
@@ -4,4 +4,41 @@ describe Omniauth::Census do
   it "has a version number" do
     expect(Omniauth::Census::VERSION).not_to be nil
   end
+
+  context ".provider_endpoint" do
+    it "returns the staging url by default" do
+      expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://census-app-staging.herokuapp.com")
+    end
+
+    it "returns the production url if rack_env is production" do
+      safe_env({'RACK_ENV' => 'production'}) do
+        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://turing-census.herokuapp.com")
+      end
+    end
+    
+    it "returns the production url if census_env is production" do
+      safe_env({'CENSUS_ENV' => 'production'}) do
+        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://turing-census.herokuapp.com")
+      end
+    end
+  end
+
+
+  it "Will set the correct auth_url given the environment" do
+    expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://census-app-staging.herokuapp.com")
+  end
+end
+
+def safe_env(env_hash)
+  old_env = ENV.to_hash
+
+  env_hash.each do |key, value|
+    ENV[key.to_s] = value
+  end
+
+  yield
+ensure
+  old_env.each do |key, value|
+    ENV[key.to_s] = value
+  end
 end


### PR DESCRIPTION
This gem will now choose which provider to point to based on the `RACK_ENV` environment variable. It defaults to the staging app (https://census-app-staging.herokuapp.com/), and will authenticate with the production app (https://turing-census.herokuapp.com/) if `RACK_ENV=production`.

This assumes you want to use the staging census in development, although there could be an argument made that you want to use a local instance of census in development, especially because not everyone has a login for the staging census app.