### PR TITLE
Support overriding Census endpoint via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Or install it yourself as:
 
 #### Step 2: Configure OmniAuth
 
-*   Add the `CENSUS_ID`, `CENSUS_SECRET` you receive to your application's environment variables. Use the "production" values if `RACK_ENV` is set to `production`. Use the "development" values for all other environments.
+*   Add the `CENSUS_ID`, `CENSUS_SECRET` you receive to your application's environment variables. Use the "production" values if `RACK_ENV` is set to `production`. Use the "development" values for all other environments. The Census endpoint can be overridden by setting a fully qualified URL in `CENSUS_PROVIDER_ENDPOINT`.
     *   For security, please ensure that these variables are not uploaded to GitHub or any other publicly available resource. If you need assistance with keeping these secret, consider using the [Figaro](https://github.com/laserlemon/figaro) gem. _(Figaro pronunciation: /fi.ɡa.ʁɔ/)_
 
 *   Create the following file:

--- a/lib/omniauth/strategies/census.rb
+++ b/lib/omniauth/strategies/census.rb
@@ -6,13 +6,15 @@ module OmniAuth
       include OmniAuth::Strategy
 
       def self.provider_endpoint
-        
+        if ENV['CENSUS_PROVIDER_ENDPOINT'].to_s != ""
+          return ENV['CENSUS_PROVIDER_ENDPOINT']
+        end
+
         if ENV['CENSUS_ENV'] == 'production' || ENV['RACK_ENV'] == 'production'
           return "https://turing-census.herokuapp.com"
         else
           return "https://census-app-staging.herokuapp.com"
         end
-        
       end
 
       option :client_options, {
@@ -39,7 +41,6 @@ module OmniAuth
         @raw_info ||=
           access_token.get('/api/v1/user_credentials').parsed
       end
-
     end
   end
 end

--- a/omniauth-census.gemspec
+++ b/omniauth-census.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Turing School of Software Design Omniauth Strategy"
   spec.description   = "This gem makes it possible for developers to create applications that authenticate using the Turing Census identity management platform."
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/turingschool-projects/omniauth-census"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'

--- a/spec/omniauth/census_spec.rb
+++ b/spec/omniauth/census_spec.rb
@@ -21,6 +21,15 @@ describe Omniauth::Census do
         expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://turing-census.herokuapp.com")
       end
     end
+
+    it "returns the given url if present in the environment" do
+      safe_env({
+        'CENSUS_ENV' => 'production',
+        'CENSUS_PROVIDER_ENDPOINT' => 'https://foo.example.com'
+      }) do
+        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://foo.example.com")
+      end
+    end
   end
 
 


### PR DESCRIPTION
Why:

* Previously the Census endpoint would be determined based off of
  `CENSUS_ENV` or `RACK_ENV` vars and pick production or staging. This
  made testing against a locally running census instance difficult

This change addresses the need by:

* Adding `CENSUS_PROVIDER_ENDPOINT`, which will take predence over the
  environment variables to determine the Census endpoint (which could be
  running on localhost)