### PR TITLE
Use turing.io subdomains

### DIFF
--- a/lib/omniauth/strategies/census.rb
+++ b/lib/omniauth/strategies/census.rb
@@ -11,9 +11,9 @@ module OmniAuth
         end
 
         if ENV['CENSUS_ENV'] == 'production' || ENV['RACK_ENV'] == 'production'
-          return "https://turing-census.herokuapp.com"
+          return "https://login.turing.io"
         else
-          return "https://census-app-staging.herokuapp.com"
+          return "https://login-staging.turing.io"
         end
       end
 

--- a/spec/omniauth/census_spec.rb
+++ b/spec/omniauth/census_spec.rb
@@ -7,18 +7,18 @@ describe Omniauth::Census do
 
   context ".provider_endpoint" do
     it "returns the staging url by default" do
-      expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://census-app-staging.herokuapp.com")
+      expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login-staging.turing.io")
     end
 
     it "returns the production url if rack_env is production" do
       safe_env({'RACK_ENV' => 'production'}) do
-        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://turing-census.herokuapp.com")
+        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login.turing.io")
       end
     end
     
     it "returns the production url if census_env is production" do
       safe_env({'CENSUS_ENV' => 'production'}) do
-        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://turing-census.herokuapp.com")
+        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login.turing.io")
       end
     end
 
@@ -34,7 +34,7 @@ describe Omniauth::Census do
 
 
   it "Will set the correct auth_url given the environment" do
-    expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://census-app-staging.herokuapp.com")
+    expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login-staging.turing.io")
   end
 end
 


### PR DESCRIPTION
Why:

* we deploy the staging and production census apps underneath the
  turing.io domain. We should use em!

This change addresses the need by:

* update the hardcoded endpoints to use the turing.io subdomains for
  each env.