### PR TITLE
Add Census::Client to fetch current_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ Link
 
 `<%= link_to 'Login with Census', '/auth/census' %>`
 
+
+## Getting data from the Census API
+
+Use the `Census::Client` included in this gem. It currently supports fetching
+the currently logged in user (via the token). Given a token its usage is:
+
+`census_user = Census::Client.new(token: token).get_current_user`
+
+It will return an instance of `Census::User` or raise an error that
+should be handled. The error is one of:
+  * Census::Client::InvalidResponseError
+  * Census::Client::UnauthorizedError
+  * Census::Client::NotFoundError
+
 ## Note about environments
 
 Since you can perform destructive actions on Census with your application keys,

--- a/lib/census/client.rb
+++ b/lib/census/client.rb
@@ -1,0 +1,62 @@
+require 'census/user'
+
+module Census
+  class Client
+    BASE_URL = OmniAuth::Strategies::Census.provider_endpoint
+
+    class InvalidResponseError < StandardError; end;
+    class UnauthorizedError < StandardError; end;
+    class NotFoundError < StandardError; end;
+
+    def initialize(token:)
+      @token = token
+    end
+
+    def get_current_user
+      response = Faraday.get(user_url)
+
+      begin
+        response_json = JSON.parse(response.body)
+      rescue JSON::ParserError => e
+        raise InvalidResponseError.new(e.message)
+      end
+
+      if response.status == 401
+        raise UnauthorizedError.new(parse_errors(response_json))
+      elsif response.status == 404
+        raise NotFoundError.new(parse_errors(response_json))
+      end
+
+      map_response_to_user(response_json)
+    end
+
+    private
+
+    def map_response_to_user(user_json)
+      Census::User.new(
+        cohort_name: (user_json["cohort"] || {})["name"],
+        email: user_json["email"],
+        first_name: user_json["first_name"],
+        git_hub: user_json["git_hub"],
+        groups: user_json["groups"].map { |group| group["name"] },
+        id: user_json["id"],
+        image_url: user_json["image_url"],
+        last_name: user_json["last_name"],
+        roles: user_json["roles"].map { |role| role["name"] },
+        slack: user_json["slack"],
+        stackoverflow: user_json["stackoverflow"],
+        twitter: user_json["twitter"],
+      )
+    end
+
+    def parse_errors(response_json)
+      response_json["errors"].join(",")
+    end
+
+    def user_url
+      user_url = "/api/v1/user_credentials"
+
+      BASE_URL + user_url + "?access_token=#{@token}"
+    end
+  end
+end

--- a/lib/census/user.rb
+++ b/lib/census/user.rb
@@ -1,0 +1,46 @@
+module Census
+  class User
+    attr_reader(
+      :cohort_name,
+      :email,
+      :first_name,
+      :git_hub,
+      :groups,
+      :id,
+      :image_url,
+      :last_name,
+      :roles,
+      :slack,
+      :stackoverflow,
+      :twitter
+    )
+
+    def initialize(
+      cohort_name:,
+      email:,
+      first_name:,
+      git_hub:,
+      groups:,
+      id:,
+      image_url:,
+      last_name:,
+      roles:,
+      slack:,
+      stackoverflow:,
+      twitter:
+    )
+      @cohort_name = cohort_name
+      @email = email
+      @first_name = first_name
+      @git_hub = git_hub
+      @groups = groups
+      @id = id
+      @image_url = image_url
+      @last_name = last_name
+      @roles = roles
+      @slack = slack
+      @stackoverflow = stackoverflow
+      @twitter = twitter
+    end
+  end
+end

--- a/lib/omniauth-census.rb
+++ b/lib/omniauth-census.rb
@@ -1,1 +1,2 @@
 require 'omniauth/census'
+require "census/client"

--- a/spec/census/client_spec.rb
+++ b/spec/census/client_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe Census::Client do
+  describe '#get_current_user' do
+    it 'does a thing' do
+      user_attributes = {
+        "id"=>86,
+        "first_name"=>"Simon",
+        "last_name"=>"Tar",
+        "cohort"=>{"name"=>"1401-BE"},
+        "image_url"=>"https://img.example.com",
+        "email"=>"foo@turing.io",
+        "slack"=>"sl",
+        "stackoverflow"=>"so",
+        "linked_in"=>"li",
+        "git_hub"=>"gh",
+        "twitter"=>"tw",
+        "roles"=> [
+          {"id"=>27, "name"=>"staff", "created_at"=>"2017-02-08T21:09:38.545Z", "updated_at"=>"2017-02-08T21:09:38.545Z"},
+          {"id"=>1, "name"=>"admin", "created_at"=>"2016-12-21T21:11:33.140Z", "updated_at"=>"2016-12-21T21:11:33.140Z"}
+         ],
+        "groups"=>[{ "name"=>"LGBTQ" }],
+        "token"=>"foo"
+      }
+
+      response_stub = double(status: 200, body: user_attributes.to_json)
+      allow(Faraday).to receive(:get).and_return(response_stub)
+
+      client = Census::Client.new(token: "foo")
+
+      user = client.get_current_user
+
+      expect(user.cohort_name).to eq("1401-BE")
+      expect(user.email).to eq("foo@turing.io")
+      expect(user.first_name).to eq("Simon")
+      expect(user.git_hub).to eq("gh")
+      expect(user.groups).to match_array(["LGBTQ"])
+      expect(user.id).to eq(86)
+      expect(user.image_url).to eq("https://img.example.com")
+      expect(user.last_name).to eq("Tar")
+      expect(user.roles).to match_array(["admin", "staff"])
+      expect(user.slack).to eq("sl")
+      expect(user.stackoverflow).to eq("so")
+      expect(user.twitter).to eq("tw")
+    end
+
+    context 'with a not found user' do
+      it 'raises auth error' do
+        response_stub = double(status: 404, body: { errors: ["foo"] }.to_json )
+        allow(Faraday).to receive(:get).and_return(response_stub)
+
+        client = Census::Client.new(token: "valid-token")
+
+        expect {
+          client.get_current_user
+        }.to raise_error(Census::Client::NotFoundError)
+      end
+    end
+
+    context 'with invalid token' do
+      it 'raises auth error' do
+        response_stub = double(status: 401, body: { errors: ["foo"] }.to_json )
+        allow(Faraday).to receive(:get).and_return(response_stub)
+
+        client = Census::Client.new(token: "foo")
+
+        expect {
+          client.get_current_user
+        }.to raise_error(Census::Client::UnauthorizedError)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "omniauth/census"
+require "census/client"


### PR DESCRIPTION
Why:

* we want to make it easy for developers to fetch data from census

This change addresses the need by:

* adding a census client to fetch the current user (and more resources
  to come soon)

As part of https://trello.com/c/Wlh1EH9b/304-integrate-census-login-to-enroll

Usage: given a `token`

`census_user = Census::Client.new(token: token).get_current_user`

it will return an instance of `Census::User` or raise an error that
should be handled:
  * InvalidResponseError
  * UnauthorizedError
  * NotFoundError