### PR TITLE
Implement user invite method

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ should be handled. The error is one of:
   * Census::Client::UnauthorizedError
   * Census::Client::NotFoundError
 
+If you are performing actions on behalf of an oauth application (not on behalf
+of a specific user) you can fetch a token given the client id and secret with
+the following:
+
+```
+credentials = Census::Client.generate_token(client_id: 'foo', client_secret: 'bar')
+```
+
+It will return a `Census::Credentials` object or raise an error.
+
 ## Note about environments
 
 Since you can perform destructive actions on Census with your application keys,

--- a/lib/census/credentials.rb
+++ b/lib/census/credentials.rb
@@ -1,0 +1,22 @@
+module Census
+  class Credentials
+    attr_reader(
+      :access_token,
+      :token_type,
+      :expires_in,
+      :created_at
+    )
+
+    def initialize(
+      access_token:,
+      token_type:,
+      expires_in:,
+      created_at:
+    )
+      @access_token = access_token
+      @token_type = token_type
+      @expires_in = expires_in
+      @created_at = created_at
+    end
+  end
+end

--- a/spec/census/client_spec.rb
+++ b/spec/census/client_spec.rb
@@ -1,8 +1,25 @@
 require 'spec_helper'
 
 describe Census::Client do
+  describe '#generate_token' do
+    it 'creates a token and returns credentials' do
+      creds_json = {
+        access_token: "biglongtoken",
+        token_type: "bearer",
+        expires_in: 12345,
+        created_at: 1242597
+      }.to_json
+      response_stub = double(status: 201, body: creds_json)
+      allow(Faraday).to receive(:post).and_return(response_stub)
+
+      credentials = Census::Client.generate_token(client_id: 'foo', client_secret: 'bar')
+
+      expect(credentials.access_token).to eq("biglongtoken")
+    end
+  end
+
   describe '#get_current_user' do
-    it 'does a thing' do
+    it 'returns the user tied to the passed token' do
       user_attributes = {
         "id"=>86,
         "first_name"=>"Simon",


### PR DESCRIPTION
Why:

* we want apply to be able to invite users in census so they can have
  access to enroll

This change addresses the need by:

* adding `Census::Client#generate_token` that takes in a client id /
  secret and will return a token with `admin` scope (which is able to
  call the invitation endpoint)

There is some duplication in the Client code on handling responses,
which I'd like to circle back on once we have a better idea of how much
more we're going to implement in this client in the coming weeks /
months

Part of
https://trello.com/c/xVljwMcC/257-api-for-creating-an-invite-to-census-enroll