### PR TITLE
Update client to get single user by id

### DIFF
--- a/lib/census/client.rb
+++ b/lib/census/client.rb
@@ -58,6 +58,25 @@ module Census
       map_response_to_user(response_json)
     end
 
+    def get_user_by_id(id:)
+      response_json = get_url(url: single_user_url(id: id))
+
+      Census::User.new(
+        cohort_name: response_json["cohort"],
+        email: response_json["email"],
+        first_name: response_json["first_name"],
+        git_hub: response_json["git_hub"],
+        groups: response_json["groups"],
+        id: response_json["id"],
+        image_url: response_json["image_url"],
+        last_name: response_json["last_name"],
+        roles: response_json["roles"],
+        slack: response_json["slack"],
+        stackoverflow: response_json["stackoverflow"],
+        twitter: response_json["twitter"]
+      )
+    end
+
     private
 
     def post_url(url:, params: {})
@@ -66,7 +85,7 @@ module Census
     end
 
     def get_url(url:)
-      response = Faraday.get(user_url)
+      response = Faraday.get(url)
       handle_and_parse_response(response: response)
     end
 
@@ -115,6 +134,10 @@ module Census
 
     def user_url
       build_full_url_with_token(path: "/api/v1/user_credentials")
+    end
+
+    def single_user_url(id:)
+      build_full_url_with_token(path: "/api/v1/users/#{id}")
     end
 
     def build_full_url_with_token(path:)

--- a/spec/census/client_spec.rb
+++ b/spec/census/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Census::Client do
-  describe '#generate_token' do
+  describe '.generate_token' do
     it 'creates a token and returns credentials' do
       creds_json = {
         access_token: "biglongtoken",
@@ -18,7 +18,7 @@ describe Census::Client do
     end
   end
 
-  describe 'invite_user' do
+  describe '#invite_user' do
     it 'returns the invitation id' do
       invite_id = 1
       invite_attributes = { "invitation"=> { "id"=>invite_id } }
@@ -29,6 +29,33 @@ describe Census::Client do
       invitation = client.invite_user(email: "invited@example.com")
 
       expect(invitation.id).to eq(invite_id)
+    end
+  end
+
+  describe '#get_user_by_id' do
+    it 'returns the requested user' do
+      user_attributes = {
+        "cohort"=>"1401-BE",
+        "email"=>"foo@turing.io",
+        "first_name"=>"Simon",
+        "git_hub"=>"gh",
+        "groups"=>["LGBTQ"],
+        "id"=>86,
+        "image_url"=>"https://img.example.com",
+        "last_name"=>"Tar",
+        "linked_in"=>"li",
+        "roles"=> ["student"],
+        "slack"=>"sl",
+        "stackoverflow"=>"so",
+        "twitter"=>"tw"
+      }
+      response_stub = double(status: 200, body: user_attributes.to_json)
+      allow(Faraday).to receive(:get).and_return(response_stub)
+      client = Census::Client.new(token: "foo")
+
+      user = client.get_user_by_id(id: 86)
+
+      expect(user.cohort_name).to eq("1401-BE")
     end
   end
 


### PR DESCRIPTION
Why:

* we want to be able to fetch users by id for admins performing bulk
  operations in Enroll

This change addresses the need by:

* adds `get_user_by_id`

https://trello.com/c/xVF0CYSF/330-update-census-client-to-fetch-user-by-id