### PR TITLE
Allow optional name to be passed to invitation call

### DIFF
--- a/lib/census/client.rb
+++ b/lib/census/client.rb
@@ -47,8 +47,11 @@ module Census
     end
 
     # requires admin scope
-    def invite_user(email:)
-      response_json = post_url(url: invitations_url, params: { invitation: { email: email  } })
+    def invite_user(email:, name: nil)
+      response_json = post_url(
+        url: invitations_url,
+        params: { invitation: { email: email, name: name } }
+      )
 
       Census::Invitation.new(id: response_json["invitation"]["id"])
     end

--- a/spec/census/client_spec.rb
+++ b/spec/census/client_spec.rb
@@ -26,7 +26,7 @@ describe Census::Client do
       allow(Faraday).to receive(:post).and_return(response_stub)
       client = Census::Client.new(token: "foo")
 
-      invitation = client.invite_user(email: "invited@example.com")
+      invitation = client.invite_user(email: "invited@example.com", name: "Mildred")
 
       expect(invitation.id).to eq(invite_id)
     end


### PR DESCRIPTION
Why:

* We want the user's name when we invite them

This change addresses the need by:

* adding an optional name field (for backwards compatibility)

https://trello.com/c/xHzkrX5v/377-pass-name-through-to-census-invite