### PR TITLE
Add all_users method call

### DIFF
--- a/lib/census/client.rb
+++ b/lib/census/client.rb
@@ -80,6 +80,17 @@ module Census
       )
     end
 
+    def get_users
+      # NB: this endpoint is currently not paginated
+      response_json = get_url(
+        url: build_full_url_with_token(path: "/api/v1/users")
+      )
+
+      response_json.map do |census_user|
+        map_response_to_user(census_user)
+      end
+    end
+
     private
 
     def post_url(url:, params: {})

--- a/spec/census/client_spec.rb
+++ b/spec/census/client_spec.rb
@@ -32,6 +32,38 @@ describe Census::Client do
     end
   end
 
+  describe '#get_users' do
+    it 'returns all the users' do
+      user_attributes = {
+        "id"=>86,
+        "first_name"=>"Simon",
+        "last_name"=>"Tar",
+        "cohort"=>{"name"=>"1401-BE"},
+        "image_url"=>"https://img.example.com",
+        "email"=>"foo@turing.io",
+        "slack"=>"sl",
+        "stackoverflow"=>"so",
+        "linked_in"=>"li",
+        "git_hub"=>"gh",
+        "twitter"=>"tw",
+        "roles"=> [
+          {"id"=>27, "name"=>"staff", "created_at"=>"2017-02-08T21:09:38.545Z", "updated_at"=>"2017-02-08T21:09:38.545Z"},
+          {"id"=>1, "name"=>"admin", "created_at"=>"2016-12-21T21:11:33.140Z", "updated_at"=>"2016-12-21T21:11:33.140Z"}
+         ],
+        "groups"=>[{ "name"=>"LGBTQ" }],
+      }
+      users = [user_attributes]
+      response_stub = double(status: 200, body: users.to_json)
+      allow(Faraday).to receive(:get).and_return(response_stub)
+      client = Census::Client.new(token: "foo")
+
+      users = client.get_users
+
+      expect(users.first.id).to eq(86)
+      expect(users.first.cohort_name).to eq("1401-BE")
+    end
+  end
+
   describe '#get_user_by_id' do
     it 'returns the requested user' do
       user_attributes = {


### PR DESCRIPTION
Why:

* we want to fetch all the users to persist some pointers in Tela

This change addresses the need by:

* adding the `all_users` method that returns all the users. The related
  endpoint in Census is currently not paginated. When we bump into
  performance issues, we can paginate it and update this call here.