### PR TITLE
Make default urls .edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,18 @@ It may be the case that you do not currently have a login in the staging environ
 
 Once you have logged in and set up your account:
 
-* Sign in to Census Staging at [https://login-staging.turing.io](https://login-staging.turing.io).
-* Visit [Your Census Applications](https://login-staging.turing.io/oauth/applications) and register your app.
+* Sign in to Census Staging at [https://login-staging.turing.edu](https://login-staging.turing.edu).
+* Visit [Your Census Applications](https://login-staging.turing.edu/oauth/applications) and register your app.
 * Provide an application name
 * Provide an application redirect uri (e.g. http://localhost:3000/auth/census/callback)
 * Note the values for "Application Id" and "Secret". These are the values you will use in your dev environment.
-* Follow the steps above, but at <https://login-staging.turing.io>. You will
+* Follow the steps above, but at <https://login-staging.turing.edu>. You will
   get a different set of "Application Id" and "Secret". These are your
   "development" values.
 
 ##### Registering with Census Production
 
-When you are ready to deploy, perform the same steps when registering with Census Staging on the [production version of Census](https://login.turing.io).
+When you are ready to deploy, perform the same steps when registering with Census Staging on the [production version of Census](https://login.turing.edu).
 
 Note that Census requires you to use `https` when creating a callback URL in the production environment. It may be beneficial for you to force users to connect over SSL.
 

--- a/lib/omniauth/census/version.rb
+++ b/lib/omniauth/census/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Census
-    VERSION = "0.1.13"
+    VERSION = "0.2.0"
   end
 end

--- a/lib/omniauth/strategies/census.rb
+++ b/lib/omniauth/strategies/census.rb
@@ -11,9 +11,9 @@ module OmniAuth
         end
 
         if ENV['CENSUS_ENV'] == 'production' || ENV['RACK_ENV'] == 'production'
-          return "https://login.turing.io"
+          return "https://login.turing.edu"
         else
-          return "https://login-staging.turing.io"
+          return "https://login-staging.turing.edu"
         end
       end
 

--- a/spec/census/client_spec.rb
+++ b/spec/census/client_spec.rb
@@ -40,7 +40,7 @@ describe Census::Client do
         "last_name"=>"Tar",
         "cohort"=>{"name"=>"1401-BE"},
         "image_url"=>"https://img.example.com",
-        "email"=>"foo@turing.io",
+        "email"=>"foo@turing.edu",
         "slack"=>"sl",
         "stackoverflow"=>"so",
         "linked_in"=>"li",
@@ -74,7 +74,7 @@ describe Census::Client do
         "cohort"=>{"id"=>13, "name"=>"1602-BE"},
         "cohort_id"=>13,
         "image_url"=>"https://img.example.com",
-        "email"=>"foo@turing.io",
+        "email"=>"foo@turing.edu",
         "slack"=>"sl",
         "stackoverflow"=>"so",
         "linked_in"=>"li",
@@ -95,7 +95,7 @@ describe Census::Client do
         "cohort"=>{"id"=>1, "name"=>"1401-BE"},
         "cohort_id"=>1,
         "image_url"=>"https://img.example.com",
-        "email"=>"foo@turing.io",
+        "email"=>"foo@turing.edu",
         "slack"=>"sl",
         "stackoverflow"=>"so",
         "linked_in"=>"li",
@@ -125,7 +125,7 @@ describe Census::Client do
     it 'returns the requested user' do
       user_attributes = {
         "cohort"=>"1401-BE",
-        "email"=>"foo@turing.io",
+        "email"=>"foo@turing.edu",
         "first_name"=>"Simon",
         "git_hub"=>"gh",
         "groups"=>["LGBTQ"],
@@ -156,7 +156,7 @@ describe Census::Client do
         "last_name"=>"Tar",
         "cohort"=>{"name"=>"1401-BE"},
         "image_url"=>"https://img.example.com",
-        "email"=>"foo@turing.io",
+        "email"=>"foo@turing.edu",
         "slack"=>"sl",
         "stackoverflow"=>"so",
         "linked_in"=>"li",
@@ -178,7 +178,7 @@ describe Census::Client do
       user = client.get_current_user
 
       expect(user.cohort_name).to eq("1401-BE")
-      expect(user.email).to eq("foo@turing.io")
+      expect(user.email).to eq("foo@turing.edu")
       expect(user.first_name).to eq("Simon")
       expect(user.git_hub).to eq("gh")
       expect(user.groups).to match_array(["LGBTQ"])

--- a/spec/omniauth/census_spec.rb
+++ b/spec/omniauth/census_spec.rb
@@ -7,18 +7,18 @@ describe Omniauth::Census do
 
   context ".provider_endpoint" do
     it "returns the staging url by default" do
-      expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login-staging.turing.io")
+      expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login-staging.turing.edu")
     end
 
     it "returns the production url if rack_env is production" do
       safe_env({'RACK_ENV' => 'production'}) do
-        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login.turing.io")
+        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login.turing.edu")
       end
     end
-    
+
     it "returns the production url if census_env is production" do
       safe_env({'CENSUS_ENV' => 'production'}) do
-        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login.turing.io")
+        expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login.turing.edu")
       end
     end
 
@@ -34,7 +34,7 @@ describe Omniauth::Census do
 
 
   it "Will set the correct auth_url given the environment" do
-    expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login-staging.turing.io")
+    expect(OmniAuth::Strategies::Census.provider_endpoint).to eq("https://login-staging.turing.edu")
   end
 end
 


### PR DESCRIPTION
With the org moving from .io to .edu, Census now lives at login.turing.edu. Other apps that are using this gem have to set `CENSUS_PROVIDER_ENDPOINT` to `https://login.turing.edu`. But we should update these default settings so that that is not needed.